### PR TITLE
Updated Automated installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ OSX: copy this directory into ~/Library/Application Support/Sublime Text {2,3}/P
 
 ### Automated installation
 
-This package is not available via Package Control yet.
+1. Run Package Control: Add Repository and put in `https://github.com/jkeroes/dreamhost-template`. 
+2. Run Package Control: Install Package and search for `dreamhost-template`. 
+3. Install


### PR DESCRIPTION
It only takes one extra step to install automatically if the package isn't in the package control channel.
